### PR TITLE
Registration: drop lifetime "most recently supplied value re-use"

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -696,9 +696,7 @@ URI Template Variables:
   lt :=
   : Lifetime (optional). Lifetime of the registration in seconds. Range of 60-4294967295.
     If no lifetime is included in the initial registration, a default value of
-    86400 (24 hours) SHOULD be assumed. If the lt parameter is not included in a
-    registration refresh  or update operation, the most recently supplied value SHALL be
-    re-used.
+    86400 (24 hours) SHOULD be assumed.
 
   con :=
   : Context (optional). This parameter sets the scheme, address, port and path at


### PR DESCRIPTION
The mechanism is useful in updates, but at the registration interface
they do not make sense.

Closes: https://github.com/core-wg/resource-directory/issues/33