### PR TITLE
Fixes for the idnits checker

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -288,7 +288,7 @@ The Entity-Relationship (ER) models shown in {{fig-ER-WKC}} and {{fig-ER-RD}} mo
 
 ~~~~
                     +----------------------+
-                    |   /.well-known/core  | 
+                    |   /.well-known/core  |
                     +----------------------+
                                |
                                | 1
@@ -322,7 +322,7 @@ The Entity-Relationship (ER) models shown in {{fig-ER-WKC}} and {{fig-ER-RD}} mo
 The model shown in {{fig-ER-WKC}} models the contents of /.well-known/core which contains:
 
 * a set of links belonging to the host
- 
+
 The names of the attributes of the links correspond with the link-format attributes that can be set. A link has the following attributes:
 
 * Unique rt (resource type)
@@ -334,10 +334,10 @@ The names of the attributes of the links correspond with the link-format attribu
 
 
 ~~~~
-             +----------------------+ 
-             |  resource-directory  |  
-             +----------------------+  
-                        | 
+             +----------------------+
+             |  resource-directory  |
+             +----------------------+
+                        |
                         |         oooooooooooo  0-1
                         |        o MC address o---+
                         |         oooooooooooo    |
@@ -348,10 +348,10 @@ The names of the attributes of the links correspond with the link-format attribu
                         |                         |
                     0-n |                         | 1+
  ooooooo     1  +---------------+          ///////\\\\\\
-o  con  o-------|  registration |---------< composed of >    
+o  con  o-------|  registration |---------< composed of >
  ooooooo        +---------------+          \\\\\\\//////
                     |       |
-                    |       +--------------+  
+                    |       +--------------+
        oooooooo   1 |                      |
       o  loc   o----+                 /////\\\\
        oooooooo     |                < contains >
@@ -567,7 +567,7 @@ This section defines the required set of REST interfaces between a Resource Dire
 CoAP {{RFC7252}}, these REST interfaces can also be realized using HTTP {{RFC7230}}.
 In all definitions in this section, both CoAP response codes (with dot notation) and HTTP response codes
 (without dot notation) are shown. An RD implementing this specification MUST support
-the discovery, registration, update, lookup, and removal interfaces defined in this section. 
+the discovery, registration, update, lookup, and removal interfaces defined in this section.
 
 All operations on the contents of the Resource Directory MUST be atomic and idempotent.
 
@@ -1696,7 +1696,7 @@ address as these may change over the lifetime of an Endpoint.
 
 Every operation performed by an Endpoint or Client on a resource directory
 SHOULD be mutually authenticated using Pre-Shared Key, Raw Public Key or
-Certificate based security. 
+Certificate based security.
 
 Consider te following threat: two devices A and B are managed by a single server. Both devices have unique, per-device credentials for use with DTLS to make sure that only parties with authorization to access A or B can do so.
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1658,16 +1658,24 @@ constructed by the resource directory:
 ~~~~
 Req: POST /rd?ep=mynode
 
-</sensors>;ct=40;title="Sensor Index";anchor="coap://sensor1.example.com",
-</sensors/temp>;rt="temperature-c";if="sensor";anchor="coap://sensor1.example.com",
-</sensors/light>;rt="light-lux";if="sensor";anchor="coap://sensor1.example.com",
-<http://www.example.com/sensors/t123>;anchor="coap://sensor1.example.com/sensors/temp";rel="describedby",
-</t>;anchor="coap://sensor1.example.com/sensors/temp";rel="alternate",
-</sensors>;ct=40;title="Sensor Index";anchor="coap://sensor2.example.com",
-</sensors/temp>;rt="temperature-c";if="sensor";anchor="coap://sensor2.example.com",
-</sensors/light>;rt="light-lux";if="sensor";anchor="coap://sensor2.example.com",
-<http://www.example.com/sensors/t123>;anchor="coap://sensor2.example.com/sensors/temp";rel="describedby",
-</t>;anchor="coap://sensor2.example.com/sensors/temp";rel="alternate"
+</sensors>;ct=40;title="Sensor Index";
+    anchor="coap://sensor1.example.com",
+</sensors/temp>;rt="temperature-c";if="sensor";
+    anchor="coap://sensor1.example.com",
+</sensors/light>;rt="light-lux";if="sensor";
+    anchor="coap://sensor1.example.com",
+<http://www.example.com/sensors/t123>;rel="describedby";
+    anchor="coap://sensor1.example.com/sensors/temp",
+</t>;rel="alternate";anchor="coap://sensor1.example.com/sensors/temp",
+</sensors>;ct=40;title="Sensor Index";
+    anchor="coap://sensor2.example.com",
+</sensors/temp>;rt="temperature-c";if="sensor";
+    anchor="coap://sensor2.example.com",
+</sensors/light>;rt="light-lux";if="sensor";
+    anchor="coap://sensor2.example.com",
+<http://www.example.com/sensors/t123>;rel="describedby";
+    ;anchor="coap://sensor2.example.com/sensors/temp",
+</t>;rel="alternate";anchor="coap://sensor2.example.com/sensors/temp"
 ~~~~
 
 # Security Considerations
@@ -1915,7 +1923,7 @@ of the presence sensor are registered as members of the group.
 Req: POST coap://[2001:db8:4::ff]/rd-group
 ?gp=grp_R2-4-015&con=coap://[ff05::1]
 Payload:
-[ request still unclear -- can we require group manager to just look up the endpoint registrations first? ]
+[ request still unclear -- see https://github.com/core-wg/resource-directory/issues/48 ]
 <>;ep=lm_R2-4-015_wndw,
 <>;ep=lm_R2-4-015_door,
 <>;ep=ps_R2-4-015_door

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -67,7 +67,7 @@ normative:
   RFC6690:
   RFC2119:
   RFC3986:
-  RFC5226:
+  RFC8126:
   RFC5988:
 #  RFC6335: portreg
   RFC6570:
@@ -1775,7 +1775,7 @@ Initial entries in this sub-registry are as follows:
 {: #tab-registry title='RD Parameters'}
 
 The IANA policy for future additions to the sub-registry is "Expert Review"
-as described in {{RFC5226}}.
+as described in {{RFC8126}}.
 
 
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -334,46 +334,46 @@ The names of the attributes of the links correspond with the link-format attribu
 
 
 ~~~~
-                            +----------------------+ 
-                            |  resource-directory  |  
-                            +----------------------+  
-                                       | 
-                                       |         oooooooooooo  0-1
-                                       |        o MC address o---+
-                                       |         oooooooooooo    |
-                                       |                         |
-                                  //////\\\\             0+  +--------+
-                                 < contains >----------------| group  |
-                                  \\\\\/////                 +--------+
-                                       |                         |
-                                   0-n |                         | 1+
- oooooooooooooooooooooo     1  +---------------+          ///////\\\\\\
-o  scheme://authority: o-------|  registration |---------< composed of >    
- oooooooooooooooooooooo        +---------------+          \\\\\\\//////
-                                   |       |
-                                   |       +--------------+  
-                      oooooooo   1 |                      |
-                     o  loc   o----+                 /////\\\\
-                      oooooooo     |                < contains >
-                                   |                 \\\\\/////
-                      oooooooo   1 |                      |
-                     o   ep   o----+                      | 1+
-                      oooooooo     |             +------------------+
-                                   |             |      link        |
-                      oooooooo 0-1 |             +------------------+
-                     o    d   o----+                      |
-                      oooooooo     |                      |  1   ooooooo
-                                   |                      +-----o href  o
-                      oooooooo 0-1 |                      |      ooooooo
-                     o   et   o----+     ooooooooooo   0+ |
-                      oooooooo     |    o  target   o-----+
-                                   |    o attribute o     | 0+   oooooo
-                      oooooooo 0-1 |     ooooooooooo      +-----o rel  o
-                     o   lt   o----+                      |      oooooo
-                      oooooooo                            |
-                                                          | 0-1 oooooooo
-                                                          +----o anchor o
-                                                                oooooooo
+             +----------------------+ 
+             |  resource-directory  |  
+             +----------------------+  
+                        | 
+                        |         oooooooooooo  0-1
+                        |        o MC address o---+
+                        |         oooooooooooo    |
+                        |                         |
+                   //////\\\\             0+  +--------+
+                  < contains >----------------| group  |
+                   \\\\\/////                 +--------+
+                        |                         |
+                    0-n |                         | 1+
+ ooooooo     1  +---------------+          ///////\\\\\\
+o  con  o-------|  registration |---------< composed of >    
+ ooooooo        +---------------+          \\\\\\\//////
+                    |       |
+                    |       +--------------+  
+       oooooooo   1 |                      |
+      o  loc   o----+                 /////\\\\
+       oooooooo     |                < contains >
+                    |                 \\\\\/////
+       oooooooo   1 |                      |
+      o   ep   o----+                      | 1+
+       oooooooo     |             +------------------+
+                    |             |      link        |
+       oooooooo 0-1 |             +------------------+
+      o    d   o----+                      |
+       oooooooo     |                      |  1   ooooooo
+                    |                      +-----o href  o
+       oooooooo 0-1 |                      |      ooooooo
+      o   et   o----+     ooooooooooo   0+ |
+       oooooooo     |    o  target   o-----+
+                    |    o attribute o     | 0+   oooooo
+       oooooooo 0-1 |     ooooooooooo      +-----o rel  o
+      o   lt   o----+                      |      oooooo
+       oooooooo                            |
+                                           | 0-1 oooooooo
+                                           +----o anchor o
+                                                 oooooooo
 ~~~~
 {: #fig-ER-RD title='E-R Model of the content of the Resource Directory' align="left"}
 
@@ -385,13 +385,13 @@ The model shown in {{fig-ER-RD}} models the contents of the resource directory w
 A Group has one Multicast address attribute and is composed of 0 to n1 endpoints. A registration is associated with one endpoint (ep). An endpoint can be part of 0 to k1 Groups . An endpoint is contained in 1 to m RDs. A registration defines a set of links as defined for /.well-known/core. A Registration has six attributes:
 
 * one ep (endpoint with a unique  name)
-* string describing the scheme://authority part 
+* one con (a string describing the scheme://authority part)
 * one lt (lifetime),
 * optional one et (endpoint type to add semantic information),
 * one loc (location in the RD)
 * optional one d (domain for query filtering)
 
-The cardinality of the scheme://authority string is currently 1 (n2 = 1). The value of the scheme://authority string is copied from the value of the "hosts" relation and overwritten by the value of the con query parameter.
+The cardinality of con is currently 1 (n2 = 1). The value of con is copied from the value of the "hosts" relation and overwritten by the value of the con query parameter.
 
 ## Use Case: Cellular M2M {#cellular}
 


### PR DESCRIPTION
I've had to override the commit-time check for [idnits](https://tools.ietf.org/tools/idnits/) recently; these edits make the document idnits clean again.

I don't expect much controversy over those, but @petervanderstok, are you OK with labelling scheme://host:port as "con" in the diagram? (As it was, it's too wide for an RFC).