### PR TITLE
Make the registration idempotent at request level

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -869,11 +869,13 @@ Success:
   of the registration and for maintaining the content of the
   registered links, including updating and deleting links.
 
-Failure:
-: 4.00 "Bad Request" or 400 "Bad Request". Malformed request.
+  A registration with an already registered ep and d value pair
+  responds with the same success code and Location as the original registration;
+  the set of links registered with the endpoint is replaced with the links
+  from the payload.
 
 Failure:
-: 4.09 "Conflict" or 409 "Conflict". Attempt to create a registration resource with ep and d value pair which is already present in an earlier created registration resource.
+: 4.00 "Bad Request" or 400 "Bad Request". Malformed request.
 
 Failure:
 : 5.03 "Service Unavailable" or 503 "Service Unavailable". Service could not perform the operation.


### PR DESCRIPTION
The description of the Registration interface describes it as
idempotent, I think it should be idempotent on CoAP and not only on
application level -- the same request results in the same response with
no further state change.

As to what happens when the re-registration arrives with a *different*
set of links, there we have options; I went for "replaces the
registration" here, but a 4.09 *in that case* would be just as valid an
option.

@petervanderstok, that topic came up with the removal of the plurality removal at https://github.com/core-wg/resource-directory/pull/78#discussion_r147684686. Do you agree with the basic proposition of "an unmodified request should be 2.04", and do you think replacing is the right way, or 4.09 if the links don't match?