### PR TITLE
Examples: Use absolute reference to same server

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1790,17 +1790,22 @@ Res: 2.05 Content
 ~~~~
 
 The following example shows a client performing a lookup for all endpoints
-in a particular group, with one endpoint hosted by another RD:
+in a particular group, with one endpoint registered over TCP:
 
 ~~~~
 Req: GET /rd-lookup/ep?gp=lights1
 
 Res: 2.05 Content
-<coap://[other-rd]/rd/abcd>;con="coap://[2001:db8:3::123]:61616";
-anchor="coap://[other-rd]";ep="node1";et="oic.d.sensor";ct="40";lt="600",
+<coap+tcp://rd.example.com/rd/abcd>;con="coap://[2001:db8:3::123]:61616";
+ep="node1";et="oic.d.sensor";ct="40";lt="600",
 </rd/efgh>;con="coap://[2001:db8:3::124]:61616";
 ep="node2";et="oic.d.sensor";ct="40";lt="600"
 ~~~~
+
+(The RD server could have and expose an equivalent `coap://rd.exaple.com/rd/abcd` resource
+for that registration that could be expressed as `</rd/abcd>` here,
+but is under no obligtion to do so, and this RD chose not to.)
+
 
 The following example shows a client performing a lookup for all groups the
 endpoint "node1" belongs to:


### PR DESCRIPTION
This is to avoid opening the questions associated with what it means to
have a group member's registration hosted on another RD; those questions
are better dealt with in their own document.

See discussion on [1].

[1]: https://mailarchive.ietf.org/arch/msg/core/IYkEs59MMdPWPH5nOjiYyO6juFY

----

Authors, do you think that this edit is a good trade-off between the two cans of worms (equivalency of resources on a single server vs. distributed RDs) involved?