### PR TITLE
lookup filtering on href: Match against resolved paths

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1644,6 +1644,7 @@ Attributes that are defined as "link-type" match if the search value matches any
 A link also matches a search criterion if the link that would be produced for any of its containing entities would match the criterion, or an entity contained in it would: A search criterion matches an endpoint if it matches the endpoint itself, any of the groups it is contained in or any resource it contains. A search criterion matches a resource if it matches the resource itself, the resource's endpoint, or any of the endpoint's groups.
 
 Note that `href` is also a valid search criterion and matches target references. Like all search criteria, on a resource lookup it can match the target reference of the resource link itself, but also the registration resource of the endpoint that registered it, or any group resource that endpoint is contained in.
+Queries for resource link targets MUST be in absolute form and are matched against a resolved link target. Queries for groups and endpoints SHOULD be expressed in path-absolute form if possible and MUST be expressed in absolute form otherwise; the RD SHOULD recognize either.
 
 Clients that are interested in a lookup result repeatedly or continuously can use
 mechanisms like ETag caching, resource observation ({{RFC7641}}),


### PR DESCRIPTION
This decides the open question of how to match the `href` in a query in
favor of client simplicity.

Closes: https://github.com/core-wg/resource-directory/issues/124

---

@jimsch, @petervanderstok, would that change be OK with you and solve the issue?