### PR TITLE
Remove confusing sentence about new registration resources

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -851,8 +851,6 @@ parameter. The endpoint is responsible for refreshing the registration resource 
 period using either the registration or update interface. The registration
 interface MUST be implemented to be idempotent, so that registering twice
 with the same endpoint parameters ep and d (sector) does not create multiple registration resources.
-A new registration resource may be created at any time to supersede an existing registration,
-replacing the registration parameters and links.
 
 The following rules apply for an update identified by a given (ep, d) value pair:
 


### PR DESCRIPTION
The rules laid out below the removed sentence are pretty clear, but the
removed sentence itself can be read to contradict them ("may be created
at any time to supersede an existing registration") or at best does not
add anything.

Assuming it was left over from an older version (before the rules were
added), I suggest we remove it.

---

@petervanderstok, that's your section of expertise. Please merge if you agree or reject otherwise.