### PR TITLE
Explicitly state that a Registree-EP may keep multiple registrations

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -319,6 +319,15 @@ provided using the CoRE Link Format.
 {: #fig-hierarchy title='The resource directory information hierarchy.' align="left"}
 
 
+A Registrant-EP MAY keep concurrent registrations to more than one RD at the same time.
+Those registrations are independent of each other.
+
+That case is not expected to be implemented in typical Registrant-EP implementations.
+The EP would need to be explicitly configured to do so,
+either by having multiple discovery mechanisms or addresses configured (which are not merely fallbacks to each other),
+or by having several sets of registration data to register with (eg. multiple endpoint names).
+
+
 ## RD Content Model {#ER-model}
 
 The Entity-Relationship (ER) models shown in {{fig-ER-WKC}} and {{fig-ER-RD}} model the contents of /.well-known/core and the resource directory respectively, with entity-relationship diagrams [ER][]. Entities (rectangles) are used for concepts that exist independently. Attributes (ovals) are used for concepts that exist only in connection with a related entity. Relations (diamonds) give a semantic meaning to the relation between entities. Numbers specify the cardinality of the relations.

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -319,11 +319,12 @@ provided using the CoRE Link Format.
 {: #fig-hierarchy title='The resource directory information hierarchy.' align="left"}
 
 
-A Registrant-EP MAY keep concurrent registrations to more than one RD at the same time.
-Those registrations are independent of each other.
+A Registrant-EP MAY keep concurrent registrations to more than one RD at the same time,
+but that is not expected to supported by typical EP implementations.
+Any such registrations are independent of each other.
 
-That case is not expected to be implemented in typical Registrant-EP implementations.
-The EP would need to be explicitly configured to do so,
+For this case to occur,
+the EP would need to be explicitly configured to register multiple times:
 either by having multiple discovery mechanisms or addresses configured (which are not merely fallbacks to each other),
 or by having several sets of registration data to register with (eg. multiple endpoint names).
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -319,14 +319,12 @@ provided using the CoRE Link Format.
 {: #fig-hierarchy title='The resource directory information hierarchy.' align="left"}
 
 
-A Registrant-EP MAY keep concurrent registrations to more than one RD at the same time,
-but that is not expected to supported by typical EP implementations.
+A Registrant-EP MAY keep concurrent registrations to more than one RD at the same time
+if explicitly configured to do so,
+but that is not expected to be supported by typical EP implementations.
 Any such registrations are independent of each other.
-
-For this case to occur,
-the EP would need to be explicitly configured to register multiple times:
-either by having multiple discovery mechanisms or addresses configured (which are not merely fallbacks to each other),
-or by having several sets of registration data to register with (eg. multiple endpoint names).
+The usual expectation when multiple discovery mechanisms or addresses are configured
+is that they constitute a fallback path for a single registration.
 
 
 ## RD Content Model {#ER-model}


### PR DESCRIPTION
The implementors in RIOT asked about whether a registrant could possibly maintain multiple registrations at different RDs, and how they interact.

I think what I'm saying in this PR is obvious (though not redundant, as we don't talk about that topic otherwise), but given it was asked about, it's probably not.

What are your opinions?