### PR TITLE
Explicitly state that base= is always reported in EP lookup

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -2565,7 +2565,7 @@ Those operations are out of scope of this document, and will require media types
 ## Endpoint lookup {#ep-lookup}
 
 Endpoint lookups result in links to registration resources.
-Endpoint registration resources are annotated with their endpoint names (ep), sectors (d, if present) and registration base URI (base) as well as a constant resource type (rt="core.rd-ep"); the lifetime (lt) is not reported.
+Endpoint registration resources are annotated with their endpoint names (ep), sectors (d, if present) and registration base URI (base; reports the registrant-ep's address if no explicit base was given) as well as a constant resource type (rt="core.rd-ep"); the lifetime (lt) is not reported.
 Additional endpoint attributes are added as link attributes to their endpoint link unless their specification says otherwise.
 
 Serializations derived from Link Format, SHOULD present links to endpoints in path-absolute form or, if required, as absolute references. (This approach avoids the RFC6690 ambiguities.)


### PR DESCRIPTION
Closes: https://github.com/core-wg/resource-directory/issues/169