### PR TITLE
Coral precautions alternatives

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -2541,7 +2541,7 @@ Endpoint lookups result in links to registration resources.
 Endpoint registration resources are annotated with their endpoint names (ep), sectors (d, if present) and registration base URI (base; reports the registrant-ep's address if no explicit base was given) as well as a constant resource type (rt="core.rd-ep"); the lifetime (lt) is not reported.
 Additional endpoint attributes are added as link attributes to their endpoint link unless their specification says otherwise.
 
-Serializations derived from Link Format, SHOULD present links to endpoints in path-absolute form or, if required, as absolute references. (This approach avoids the RFC6690 ambiguities.)
+Links to endpoints SHOULD be presented in path-absolute form or, if required, as absolute references. (This avoids the RFC6690 ambiguities.)
 
 While Endpoint Lookup does expose the registration resources,
 the RD does not need to make them accessible to clients.

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1181,9 +1181,9 @@ can be looked up using the endpoint lookup interface.
 To discover the resources registered with the RD,
 a lookup interface must be provided. This lookup interface
 is defined as a default, and it is assumed that RDs may also support lookups
-to return resource descriptions in alternative formats (e.g. Atom or HTML
-Link) or using more advanced interfaces (e.g. supporting context or semantic
-based lookup).
+to return resource descriptions in alternative formats (e.g. JSON or CBOR link format {{I-D.ietf-core-links-json}})
+or using more advanced interfaces (e.g. supporting context or semantic
+based lookup) on different resources that are discovered indepenently.
 
 RD Lookup allows lookups for endpoints and resources
 using attributes defined in this document and for use with the CoRE

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -659,8 +659,10 @@ application/link-format content format (ct=40).
 Resource Directories implementing this specification MAY support additional content formats.
 
 Any additional content format supported by a Resource Directory implementing this
-specification MUST have an equivalent serialization in the application/link-format
-content format.
+specification SHOULD be able to express all the information expressible in link-format.
+It MAY be able to express information that is inexpressible in link-format,
+but those expressions SHOULD be avoided where possible.
+
 
 ## URI Discovery {#discovery}
 


### PR DESCRIPTION
lookup: Change example of alternative formats from HTML to links-json...
    
...  and set the expectation that more elaborate formats will not use this lookup interface.
    
This is an alternative way of catering for futuer formats after Peter's comment on #177; it means fewer changes, but reduces the usability of the defined lookup interfaces to link-format-ish media types for lack of the changes suggested there.
    
---

I prefer to go the other route, but specification-wise both are consistent with their examples and extensible. (To extend this, define a new interface and possibly update this document that it's sufficient to implement any lookup interface; to extend the original version in #177, just define a link format. If we did neither, any update would need to reach into the document and allow the updates of #177, incurring the danger of almost-but-not-quite compatibility).

Both versions include commit 9e1a7499253e63e4450798f0b2ac70d95a3a987e to say that media types in registration have laxer equivalence requirements; the original requirement was not even fulfilled for application/link-format itself (not every link in its data model can be expressed in its serialization), let alone any other format.