### PR TITLE
"No more jumping" edits

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1135,10 +1135,9 @@ This section describes how the registering endpoint can maintain the registratio
 
 After the initial registration, the registering endpoint retains the returned location of the Registration Resource for further operations, including refreshing the registration in order to extend the lifetime and "keep-alive" the registration. When the lifetime of the registration has expired, the RD SHOULD NOT respond to discovery queries concerning this endpoint. The RD SHOULD continue to provide access to the Registration Resource after a registration time-out occurs in order to enable the registering endpoint to eventually refresh the registration. The RD MAY eventually remove the registration resource for the purpose of garbage collection. If the Registration Resource is removed, the corresponding endpoint will need to be re-registered.
 
-The Registration Resource may also be used to inspect the registration resource using GET, update the registration, cancel the registration using DELETE, or do an endpoint lookup.
+The Registration Resource may also be used to inspect the registration resource using GET, update the registration, or cancel the registration using DELETE.
 
 These operations are described below.
-
 
 ### Registration Update {#update}
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -253,7 +253,6 @@ An endpoint is a web server associated with a scheme, IP address and port. A phy
 RD implements a set of REST interfaces for endpoints to register and maintain
 resource directory registrations, and for endpoints to
 lookup resources from the RD. An RD can be logically segmented by the use of Sectors.
-This information hierarchy is shown in {{fig-hierarchy}}.
 
 A mechanism to discover an RD using CoRE Link Format {{RFC6690}} is defined.
 
@@ -287,19 +286,6 @@ provided using the CoRE Link Format.
 
 ~~~~
 {: #fig-arch title='The resource directory architecture.' align="left"}
-
-~~~~
-               +------------+
-               |  Endpoint  |  <-- Name, Scheme, IP, Port
-               +------------+
-                     |
-                     |
-               +------------+
-               |  Resource  |  <-- Target, Parameters
-               +------------+
-
-~~~~
-{: #fig-hierarchy title='The resource directory information hierarchy.' align="left"}
 
 
 A Registrant-EP MAY keep concurrent registrations to more than one RD at the same time

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -2416,8 +2416,8 @@ Req: GET /rd-lookup/ep?et=core.rd-group
 Res: 2.01 Content
 Payload:
 </rd/501>;ep="GRP_R2-4-015";et="core.rd-group";
-                                   base="coap://[ff05:;1]",
-<rd/12>;ep=lights&et=core.rd-group;
+                                   base="coap://[ff05::1]",
+</rd/12>;ep=lights&et=core.rd-group;
                          base="coap://[ff35:30:2001:db8::1]"
 ~~~~
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1380,7 +1380,6 @@ Above rules allow the client to interpret the response as links without any furt
 The Resource Directory MAY replace the registration base URIs with a configured intermediate proxy, e.g. in the case of an HTTP lookup interface for CoAP endpoints.
 
 
-
 ## Lookup filtering
 
 Using the Accept Option, the requester can control whether the returned list is returned in CoRE Link Format (`application/link-format`, default) or in alternate content-formats (eg. from {{I-D.ietf-core-links-json}}).
@@ -1464,8 +1463,6 @@ Failure:
 
 HTTP support:
 : YES
-
-The endpoint lookup returns registration resources which can only be manipulated by the registering endpoint. Examples of endpoint lookup belong to the management aspects of the RD and are shown in {{ep-lookup}}. The resource lookup examples are shown in this section.
 
 
 ##  Resource lookup examples
@@ -1600,6 +1597,37 @@ Req: GET /rd-lookup/res?et=core.rd-group
      et="core.rd-group";
      anchor="coap://[ff35:30:2001:db8::1]"
 ~~~~
+
+## Endpoint lookup {#ep-lookup}
+
+The endpoint lookup returns registration resources which can only be manipulated by the registering endpoint.
+
+Endpoint registration resources are annotated with their endpoint names (ep), sectors (d, if present) and registration base URI (base; reports the registrant-ep's address if no explicit base was given) as well as a constant resource type (rt="core.rd-ep"); the lifetime (lt) is not reported.
+Additional endpoint attributes are added as link attributes to their endpoint link unless their specification says otherwise.
+
+Serializations derived from Link Format, SHOULD present links to endpoints in path-absolute form or, if required, as absolute references. (This approach avoids the RFC6690 ambiguities.)
+
+While Endpoint Lookup does expose the registration resources,
+the RD does not need to make them accessible to clients.
+Clients SHOULD NOT attempt to dereference or manipulate them.
+
+A Resource Directory can report endpoints in lookup that are not hosted at the same address.
+Lookup clients MUST be prepared to see arbitrary URIs as registration resources in the results
+and treat them as opaque identifiers;
+the precise semantics of such links are left to future specifications.
+
+The following example shows a client performing an endpoint type (et) lookup with  the value oic.d.sensor (which is currently a registered rt value):
+
+~~~~
+Req: GET /rd-lookup/ep?et=oic.d.sensor
+
+Res: 2.05 Content
+</rd/1234>;base="coap://[2001:db8:3::127]:61616";ep="node5";
+et="oic.d.sensor";ct="40",
+</rd/4521>;base="coap://[2001:db8:3::129]:61616";ep="node7";
+et="oic.d.sensor";ct="40";d="floor-3"
+~~~~
+
 
 # Security policies {#policies}
 
@@ -2420,39 +2448,6 @@ Changes from -01 to -02:
 *  Changed the lookup interface to accept endpoint and Domain as query string parameters to control the scope of a lookup.
 
 --- back
-
-# Registration Management {#registration-mgmt}
-
-
-
-## Endpoint lookup {#ep-lookup}
-
-Endpoint lookups result in links to registration resources.
-Endpoint registration resources are annotated with their endpoint names (ep), sectors (d, if present) and registration base URI (base; reports the registrant-ep's address if no explicit base was given) as well as a constant resource type (rt="core.rd-ep"); the lifetime (lt) is not reported.
-Additional endpoint attributes are added as link attributes to their endpoint link unless their specification says otherwise.
-
-Serializations derived from Link Format, SHOULD present links to endpoints in path-absolute form or, if required, as absolute references. (This approach avoids the RFC6690 ambiguities.)
-
-While Endpoint Lookup does expose the registration resources,
-the RD does not need to make them accessible to clients.
-Clients SHOULD NOT attempt to dereference or manipulate them.
-
-A Resource Directory can report endpoints in lookup that are not hosted at the same address.
-Lookup clients MUST be prepared to see arbitrary URIs as registration resources in the results
-and treat them as opaque identifiers;
-the precise semantics of such links are left to future specifications.
-
-The following example shows a client performing an endpoint type (et) lookup with  the value oic.d.sensor (which is currently a registered rt value):
-
-~~~~
-Req: GET /rd-lookup/ep?et=oic.d.sensor
-
-Res: 2.05 Content
-</rd/1234>;base="coap://[2001:db8:3::127]:61616";ep="node5";
-et="oic.d.sensor";ct="40",
-</rd/4521>;base="coap://[2001:db8:3::129]:61616";ep="node7";
-et="oic.d.sensor";ct="40";d="floor-3"
-~~~~
 
 
 # RD-Groups {#groups}

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1287,19 +1287,6 @@ Payload:
     if="sensor"; anchor="coaps://new.example.com:5684",
 ~~~~
 
-The following example shows a client performing and enpoint lookup for all groups.
-
-~~~~
-Req: GET /rd-lookup/ep?et=core.rd-group
-
-Res: 2.01 Content
-Payload:
-</rd/501>;ep="GRP_R2-4-015";et="core.rd-group";
-                                   base="coap://[ff05::1]",
-</rd/12>;ep=lights&et=core.rd-group;
-                         base="coap://[ff35:30:2001:db8::1]"
-~~~~
-
 ### Registration Removal {#removal}
 
 Although RD registrations have soft state and will eventually timeout after their
@@ -2512,6 +2499,19 @@ The resources of a group can be looked up like any other resource,
 and the group registrations (along with any additional registration parameters)
 can be looked up using the endpoint lookup interface.
 
+
+The following example shows a client performing and enpoint lookup for all groups.
+
+~~~~
+Req: GET /rd-lookup/ep?et=core.rd-group
+
+Res: 2.01 Content
+Payload:
+</rd/501>;ep="GRP_R2-4-015";et="core.rd-group";
+                                   base="coap://[ff05::1]",
+</rd/12>;ep=lights&et=core.rd-group;
+                         base="coap://[ff35:30:2001:db8::1]"
+~~~~
 
 # Web links and the Resource Directory {#weblink}
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1135,7 +1135,7 @@ This section describes how the registering endpoint can maintain the registratio
 
 After the initial registration, the registering endpoint retains the returned location of the Registration Resource for further operations, including refreshing the registration in order to extend the lifetime and "keep-alive" the registration. When the lifetime of the registration has expired, the RD SHOULD NOT respond to discovery queries concerning this endpoint. The RD SHOULD continue to provide access to the Registration Resource after a registration time-out occurs in order to enable the registering endpoint to eventually refresh the registration. The RD MAY eventually remove the registration resource for the purpose of garbage collection. If the Registration Resource is removed, the corresponding endpoint will need to be re-registered.
 
-The Registration Resource may also be used to inspect the registration resource using GET, update the registration, or cancel the registration using DELETE.
+The Registration Resource may also be used cancel the registration using DELETE, and to perform further operations beyond the scope of this specification.
 
 These operations are described below.
 
@@ -1350,65 +1350,12 @@ Res: 2.02 Deleted
 ~~~~
 
 
-### Read Endpoint Links {#read}
+### Further operations {#link-up}
 
-Some registering endpoints may wish to manage their links as a collection, and may need to read the current set of links stored in the registration resource, in order to determine link maintenance operations.
+Additional operations on the registration can be specified in future documents, for example:
 
-One or more links MAY be selected by using query filtering as specified in {{RFC6690}} Section 4.1
-
-If no links are selected, the Resource Directory SHOULD return an empty payload.
-
-The read request interface is specified as follows:
-
-Interaction:
-: EP -> RD
-
-Method:
-: GET
-
-URI Template:
-: {+location}{?href,rel,rt,if,ct}
-
-URI Template Variables:
-: location :=
-  : This is the Location returned by the RD as a result of a successful
-    earlier registration.
-
-: href,rel,rt,if,ct := link relations and attributes specified in the query in order to select particular links based on their relations and attributes. "href" denotes the URI target of the link. See {{RFC6690}} Sec. 4.1
-
-The following response codes are defined for this interface:
-
-Success:
-: 2.05 "Content" or 200 "OK" upon success with an `application/link-format` or other web link payload.
-
-Failure:
-: 4.00 "Bad Request" or 400 "Bad Request". Malformed request.
-
-Failure:
-: 4.04 "Not Found" or 404 "Not Found". Registration does not exist (e.g. may have expired).
-
-Failure:
-: 5.03 "Service Unavailable" or 503 "Service Unavailable". Service could not perform the operation.
-
-HTTP support: YES
-
-The following examples show successful read of the endpoint links from the RD, with example location value /rd/4521 and example registration payload of {{example-payload}}.
-
-
-~~~~
-Req: GET /rd/4521
-
-Res: 2.01 Content
-Payload:
-</sensors/temp>;ct=41;rt="temperature-c";if="sensor";
-anchor="coap://spurious.example.com:5683",
-</sensors/light>;ct=41;rt="light-lux";if="sensor"
-~~~~
-
-
-### Update Endpoint Links {#link-up}
-
-An iPATCH (or PATCH) update ({{RFC8132}}) can add, remove or change the links of a registration.
+* Send iPATCH (or PATCH) updates ({{RFC8132}}) to add, remove or change the links of a registration.
+* Use GET to read the currently stored set of links in a registration resource.
 
 Those operations are out of scope of this document, and will require media types suitable for modifying sets of links.
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -2436,7 +2436,7 @@ Changes from -01 to -02:
 --- back
 
 
-# RD-Groups {#groups}
+# Groups Registration and Lookup {#groups}
 
 The RD-Groups usage pattern allows announcing application groups inside a Resource Directory.
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1129,50 +1129,6 @@ that purpose scheme, IP address and port of the URI of the registered device is
 
 It should be noted that the value of the "base" parameter applies to all the links of the registration and has consequences for the anchor value of the individual links as exemplified in {{weblink}}. An eventual (currently non-existing) "base" attribute of the link is not affected by the value of "base" parameter in the registration.
 
-### RD-Groups {#groups}
-
-The RD-Groups usage pattern allows announcing application groups inside a Resource Directory.
-
-Groups are represented by endpoint registrations.
-Their base address is a multicast address,
-and they SHOULD be entered with the endpoint type `core.rd-group`.
-The endpoint name can also be referred to as a group name in this context.
-
-The registration is inserted into the RD by a Commissioning Tool,
-which might also be known as a group manager here.
-It performs third party registration and registration updates.
-
-The links it registers SHOULD be available on all members that join the group.
-Depending on the application, members that lack some resource
-MAY be permissible if requests to them fail gracefully.
-
-
-The following example shows a CT registering a group with the name “lights” which provides two resources.
-The directory resource path /rd
-is an example RD location discovered in a request similar to {{example-discovery}}.
-
-~~~~
-Req: POST coap://rd.example.com/rd?ep=lights&et=core.rd-group
-                                  &base=coap://[ff35:30:2001:db8::1]
-Content-Format: 40
-Payload:
-</light>;rt="light";if="core.a",
-</color-temperature>;if="core.p";u="K"
-
-Res: 2.01 Created
-Location-Path: /rd/12
-~~~~
-
-In this example, the group manager can easily permit devices that have no
-writable color-temperature to join, as they would still respond to brightness
-changing commands. Had the group instead contained a single resource that sets
-brightness and color temperature atomically, endpoints would need to support
-both properties.
-
-The resources of a group can be looked up like any other resource,
-and the group registrations (along with any additional registration parameters)
-can be looked up using the endpoint lookup interface.
-
 
 # RD Lookup {#lookup}
 
@@ -2562,6 +2518,50 @@ et="oic.d.sensor";ct="40",
 et="oic.d.sensor";ct="40";d="floor-3"
 ~~~~
 
+
+# RD-Groups {#groups}
+
+The RD-Groups usage pattern allows announcing application groups inside a Resource Directory.
+
+Groups are represented by endpoint registrations.
+Their base address is a multicast address,
+and they SHOULD be entered with the endpoint type `core.rd-group`.
+The endpoint name can also be referred to as a group name in this context.
+
+The registration is inserted into the RD by a Commissioning Tool,
+which might also be known as a group manager here.
+It performs third party registration and registration updates.
+
+The links it registers SHOULD be available on all members that join the group.
+Depending on the application, members that lack some resource
+MAY be permissible if requests to them fail gracefully.
+
+
+The following example shows a CT registering a group with the name “lights” which provides two resources.
+The directory resource path /rd
+is an example RD location discovered in a request similar to {{example-discovery}}.
+
+~~~~
+Req: POST coap://rd.example.com/rd?ep=lights&et=core.rd-group
+                                  &base=coap://[ff35:30:2001:db8::1]
+Content-Format: 40
+Payload:
+</light>;rt="light";if="core.a",
+</color-temperature>;if="core.p";u="K"
+
+Res: 2.01 Created
+Location-Path: /rd/12
+~~~~
+
+In this example, the group manager can easily permit devices that have no
+writable color-temperature to join, as they would still respond to brightness
+changing commands. Had the group instead contained a single resource that sets
+brightness and color temperature atomically, endpoints would need to support
+both properties.
+
+The resources of a group can be looked up like any other resource,
+and the group registrations (along with any additional registration parameters)
+can be looked up using the endpoint lookup interface.
 
 
 # Web links and the Resource Directory {#weblink}


### PR DESCRIPTION
This is the edit series suggested in https://github.com/core-wg/resource-directory/issues/164#issuecomment-439012643, and covers all the bycatch of the change in a (for my changes) large series.

Effectively, it rolls back the "administrative interface" change to address #164, which IMO was of good intentions but in practice caused more confusion -- plus the size of what might be the appendix interface was reduced to managable size by the removal of groups-as-an-entity and the commit addressing #77.

The changes in logical order (commit order tries to produce readable diffs that reduce the chances of errors sneaking in):
* Drop the GET on the registration resources (see #77)
* Drop fig-hierarchy (that figure made sense when there were four entities to it, but by the end it was a relic without use)
* Move group stuff into an own area (see #164), including examples that got lost in unrelated sections
* Move the administrative parts roughly back to their original locations to address #164: "Operations on the Registration Resource" to after registration (as it is how a registration continues its life cycle); endpoint lookup to the end of the lookup part (emphasising more on the resource lookup).

This reverts previous changes in two places: The registration management (administrative interface) from e7836496e95e7cf208e471928ef5a5d324f8f6d1 (as argued above), and the move of RD-Groups out of an appendix from f3ae77c43023f97fc0846f856aed5f913edea9a7 (which I missed when reviewing Peter's additions to the new-groups branch and should have protested right away; see second part of discussion in #164).