### PR TITLE
Error consolidation

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -209,18 +209,6 @@ RDAO
   A new IPv6 Neigbhbor Discovery option defined for announcing a Resource Directory's address.
 
 
-For several operations, interface templates are given in list form;
-those describe the operation participants, request codes, URIs, content formats and outcomes.
-Sections of those templates contain normative content about
-Interaction, Method, URI Template and URI Template Variables
-as well as the details of the Success condition.
-The additional sections
-on options like Content-Format and on Failure codes
-give typical cases that an implementation of the RD should deal with.
-Those serve to illustrate the typical responses
-to readers who are not yet familiar with all the details of CoAP based interfaces;
-they do not limit what a server may respond under atypical circumstances.
-
 
 # Architecture and Use Cases {#arch}
 
@@ -517,6 +505,18 @@ In all definitions in these sections, both CoAP response codes (with dot notatio
 the discovery, registration, update, lookup, and removal interfaces.
 
 All operations on the contents of the Resource Directory MUST be atomic and idempotent.
+
+For several operations, interface templates are given in list form;
+those describe the operation participants, request codes, URIs, content formats and outcomes.
+Sections of those templates contain normative content about
+Interaction, Method, URI Template and URI Template Variables
+as well as the details of the Success condition.
+The additional sections
+on options like Content-Format and on Failure codes
+give typical cases that an implementation of the RD should deal with.
+Those serve to illustrate the typical responses
+to readers who are not yet familiar with all the details of CoAP based interfaces;
+they do not limit what a server may respond under atypical circumstances.
 
 A resource directory MAY make the information submitted to it available to further
 directories, if it can ensure that a loop does not form.  The protocol used

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -947,12 +947,9 @@ Success:
   as that could conflict with query parameters during the Registration Update operation.
   Therefore, the Location-Query option MUST NOT be present in a successful response.
 
-If the registration fails with a Service Unavailable response
-and a Max-Age option or Retry-After header,
-the registering endpoint SHOULD retry the operation after the time indicated.
-If the registration fails in another way, including request timeouts,
-or if the Service Unavailable error persists after several retries,
-or indicates a longer time than the endpoint is willing to wait,
+If the registration fails, including request timeouts,
+or if delays from Service Unavailable responses with Max-Age or Retry-After
+accumulate to exceed the registrant's configured timeouts,
 it SHOULD pick another registration URI from the "URI Discovery" step
 and if there is only one or the list is exhausted,
 pick other choices from the "Finding a Resource Directory" step.
@@ -1205,11 +1202,8 @@ Success:
 Failure:
 : 4.04 "Not Found" or 404 "Not Found". Registration does not exist (e.g. may have been removed).
 
-If the registration update fails with a "Service Unavailable" response
-and a Max-Age option or Retry-After header,
-the registering endpoint SHOULD retry the operation after the time indicated.
-If the registration fails in another way, including request timeouts,
-or if the time indicated exceeds the remaining lifetime,
+If the registration fails in any way, including "Not Found" and request timeouts,
+or if the time indicated in a Service Unabailable Max-Age/Retry-After exceeds the remaining lifetime,
 the registering endpoint SHOULD attempt registration again.
 
 


### PR DESCRIPTION
This addresses #191. The net effect on word/line count is not large (saving ~60 lines and ~150 words), but it's less repetitive and IMO gives better guidance towards how to handle errors.

Will merge into -20 today unless objected to.