### PR TITLE
DNS-SD: Add coaps, coap+tcp, coaps+tcp

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -604,7 +604,7 @@ The following RD discovery mechanisms are recommended:
 
   * In managed networks with border routers that need stand-alone operation, the RDAO option is recommended (e.g. operational phase described in {{automation}}).
   * In managed networks without border router (no Internet services available), the use of a preconfigured anycast address is recommended (e.g. installation phase described in {{automation}}).
-  * The use of DNS facilities is described in {{I-D.ietf-core-rd-dns-sd}}.
+  * In networks managed using DNS-SD, the use of DNS-SD for discovery as described in {{rd-using-dnssd}} is recommended.
 
 The use of multicast discovery in mesh networks is NOT recommended.
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -669,11 +669,14 @@ RD Address:             IPv6 address of the RD.
 ### Using DNS-SD to discover a resource directory {#rd-using-dnssd}
 
 A resource directory can advertise its presence in DNS-SD
-using the service name `_core-rd._udp`
+using the service name `_core-rd._udp` (for CoAP), `_core-rd-dtls._udp` (for CoAP over UDP),
+`_core-rd._tcp` (for CoAP over TCP) or `_core-rd-tls._tcp` (for CoAP over TLS)`
 defined in this document.
+(For the WebSocket transports of CoAP, no service is defined
+as DNS-SD is typically unavailable in environments where CoAP over WebSockets).
 
-The use of that service names implies that CoAP-over-UDP is used.
-The SRV record points the client to a host name and port to use as a starting point for the URI discovery steps of {{discovery}}.
+The selection of the service indicates the protocol used, and
+the SRV record points the client to a host name and port to use as a starting point for the URI discovery steps of {{discovery}}.
 
 This section is a simplified concrete application of the more generic mechanism
 specified in {{I-D.ietf-core-rd-dns-sd}}.
@@ -1848,12 +1851,14 @@ as this defines the resource's behavior for POST requests.
 
 ## Service Names and Transport Protocol Port Number Registry
 
-IANA is asked to enter a new item into the Service Names and Transport Protocol Port Number Registry:
+IANA is asked to enter four new items into the Service Names and Transport Protocol Port Number Registry:
 
-* Service name: "core-rd"
-* Protocol: "udp"
-* Description: "Resource Directory accessed using CoAP"
-* Reference: this document
+* Service name: "core-rd",  Protocol: "udp", Description: "Resource Directory accessed using CoAP"
+* Service name "core-rd-dtls", Protocol: "udp", Description: "Resource Directory accedded using CoAP over DTLS"
+* Service name: "core-rd",  Protocol: "tcp", Description: "Resource Directory accessed using CoAP over TCP"
+* Service name "core-rd-tls", Protocol: "tcp", Description: "Resource Directory accedded using CoAP over TLS"
+
+All in common have this document as their reference.
 
 # Examples {#examples}
 


### PR DESCRIPTION
    Those were in the original proposals during IETF / on the list, but not
    in the text yet.

Depends on #229 for practical merging purposes.