### PR TITLE
DNS-SD: Explain that only UDP is defined

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -604,7 +604,7 @@ The following RD discovery mechanisms are recommended:
 
   * In managed networks with border routers that need stand-alone operation, the RDAO option is recommended (e.g. operational phase described in {{automation}}).
   * In managed networks without border router (no Internet services available), the use of a preconfigured anycast address is recommended (e.g. installation phase described in {{automation}}).
-  * The use of DNS facilities is described in {{I-D.ietf-core-rd-dns-sd}}.
+  * In networks managed using DNS-SD, the use of DNS-SD for discovery as described in {{rd-using-dnssd}} is recommended.
 
 The use of multicast discovery in mesh networks is NOT recommended.
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -671,6 +671,9 @@ RD Address:             IPv6 address of the RD.
 A resource directory can advertise its presence in DNS-SD
 using the service name `_core-rd._udp`
 defined in this document.
+(This method is currently only defined for CoAP over UDP.
+This is both for simplicity and because this is expected to be the common use case;
+analogous services for other transports can be registered once there is demand for them).
 
 The use of that service names implies that CoAP-over-UDP is used.
 The SRV record points the client to a host name and port to use as a starting point for the URI discovery steps of {{discovery}}.


### PR DESCRIPTION
This is a counter-proposal to #230. (Like that, it builds on #229).

I prefer this version, but the voices from the WG I've heard (in-room IETF106 and https://mailarchive.ietf.org/arch/msg/core/h2rExjjm1MZjMN6GAMChaRe1B8I) were that we should have this times protocols.

I'll ask more on this on the list, but unless I get positive feedback for the only-UDP version, I'll merge and upload the times-four version or #230.