### PR TITLE
Definition alignment

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1265,7 +1265,8 @@ Payload:
     rt="temperature-c";if="sensor";
     anchor="coap://local-proxy-old.example.com:5683/",
 <http://www.example.com/sensors/temp>;
-    anchor="coap://local-proxy-old.example.com:5683/sensors/temp";rel="describedby"
+    anchor="coap://local-proxy-old.example.com:5683/sensors/temp";
+    rel="describedby"
 ~~~~
 {: #example-update-base-lookup-pre title="Example lookup before a change to the base address" }
 
@@ -1289,7 +1290,8 @@ Payload:
     rt="temperature-c";if="sensor";
     anchor="coap://new.example.com:5684/",
 <http://www.example.com/sensors/temp>;
-    anchor="coap://new.example.com:5684/sensors/temp";rel="describedby"
+    anchor="coap://new.example.com:5684/sensors/temp";
+    rel="describedby"
 ~~~~
 {: #example-update-base-lookup-post title="Example lookup after a change to the base address" }
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -158,8 +158,8 @@ that resolving an empty URI reference gives the base URI without any fragment id
 
 Resource Directory
 :   A web entity that stores information about web resources and implements the
-REST interfaces defined in this specification for registration and lookup
-of those resources.
+REST interfaces defined in this specification for discovery, for the creation, the maintenance and the removal of registrations, and for lookup
+of the registered resources.
 
 Sector
 :   In the context of a Resource Directory, a sector is a


### PR DESCRIPTION
This is to address Russ's genart comment:

> Further, the definition in Section 2 does not align with the document
> Introduction, which says that an RD is used to register, maintain,
> lookup and remove information on resources.  I think these should match.