### PR TITLE
DHCP: might be used even with SLAAC

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -566,7 +566,7 @@ suitable default.
 
 3. If the address configuration of the network is performed via SLAAC,
    this is provided by the RDAO option {{rdao}}.
-4. If the address configuration of the network is performed via DHCP,
+4. When DHCP is in use,
    this could be provided via a DHCP option (no such option is defined
    at the time of writing).
 


### PR DESCRIPTION
See-Also: https://datatracker.ietf.org/doc/draft-ietf-core-resource-directory/ballot/#eric-vyncke

This is quite literally from my notes on https://datatracker.ietf.org/doc/minutes-interim-2020-core-08-202009101600/.

A bit of uncertainty remains whether this change should be two-sided. Should the line above say "When SLAAC is in use," (or "When ND is in use,"?) as well? Can RA options be used in presence of DHCP or static address configuration?