### PR TITLE
seccons: Endpoint *authorization* needs to be checked

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1741,7 +1741,7 @@ whether the identifier provided in the DTLS handshake matches the
 identifier used at the CoAP layer then it may be inclined to use the
 endpoint name for looking up what information to provision to the malicious device.
 
-Endpoint authentication needs to be checked
+Endpoint authorization needs to be checked on registration and registration resource operations
 independently of whether there are configured requirements on the credentials for a given endpoint name ({{secure-ep}})
 or whether arbitrary names are accepted ({{arbitrary-ep}}).
 


### PR DESCRIPTION
Authentication alone is never sufficient; with the
First-Come-Fist-Remembered policy of
<https://github.com/core-wg/resource-directory/pull/258>, it should be
easier to see how this is still authorization.

See-Also: https://datatracker.ietf.org/doc/draft-ietf-core-resource-directory/ballot/#roman-danyliw