### PR TITLE
registration: Add wording to help understand "mostly mandatory"

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -892,7 +892,9 @@ URI Template Variables:
 
     The maximum length of this parameter is 63 UTF-8 encoded bytes.
 
-    If the RD is configured to recognize the endpoint (e.g. based on its security context), the RD assigns an endpoint name based on a set of configuration parameter values.
+    If the RD is configured to recognize the endpoint to be authorized to use exactly one endpoint name, the RD assigns that name.
+    In that case, giving the endpoint name becomes optional for the client;
+    if the client gives any other endpoint name, it is not authorized to perform the registration.
 
   d :=
   : Sector (optional). The sector to which this endpoint belongs.

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -2153,6 +2153,8 @@ changes from -25 to -26
   * Use example URIs rather than unclear reg names (unless it's RFC6690 examples, which were kept for continuity)
   * The LwM2M example was reduced from an outdated explanation of the complete LwM2M model to a summary of how RD is used in there, with a reference to the current specification.
 
+* Registration: Wording around "mostly mandatory" has been improved, and conflicts clarified.
+
 changes from -24 to -25
 
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -899,11 +899,11 @@ URI Template Variables:
   d :=
   : Sector (optional). The sector to which this endpoint belongs.
     When this parameter is not present, the
-    RD MAY associate the endpoint with a configured default sector or leave it empty.
+    RD MAY associate the endpoint with a configured default sector
+    (possibly based on the endpoint's authorization)
+    or leave it empty.
 
     The sector is encoded like the ep parameter, and is limited to 63 UTF-8 encoded bytes as well.
-
-    The endpoint name and sector name are not set when one or both are set in an accompanying authorization token.
 
   lt :=
   : Lifetime (optional). Lifetime of the registration in seconds. Range of 1-4294967295.
@@ -2153,7 +2153,7 @@ changes from -25 to -26
   * Use example URIs rather than unclear reg names (unless it's RFC6690 examples, which were kept for continuity)
   * The LwM2M example was reduced from an outdated explanation of the complete LwM2M model to a summary of how RD is used in there, with a reference to the current specification.
 
-* Registration: Wording around "mostly mandatory" has been improved, and conflicts clarified.
+* Registration: Wording around "mostly mandatory" has been improved, conflicts clarified and sector default selection adjusted.
 
 changes from -24 to -25
 


### PR DESCRIPTION
This also answers the repeated questions that were asked about conflicts
between recognized and given ep names, and brings the wording in line
with the more consistent application of the security glossary.