### PR TITLE
Echo freshness

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1968,7 +1968,7 @@ these concerns need to be balanced:
   an attacker may create any combination of attributes ever set,
   with the attack difficulty determined by the security layer's replay properties.
 
-  For example, if {{example-freshness} were conducted without freshness assurances,
+  For example, if {{example-freshness}} were conducted without freshness assurances,
   an attacker could later reset the lifetime back to 7200.
   <!-- That is, with DTLS without replay protection, or DTLS when causing a retransmission and swallowing one message,
   or with OSCORE when swallowing all of an update's retransmission but the ep later tries again. -->

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1914,9 +1914,6 @@ Endpoint authorization needs to be checked on registration and registration reso
 independently of whether there are configured requirements on the credentials for a given endpoint name (and sector; {{secure-ep}})
 or whether arbitrary names are accepted ({{arbitrary-ep}}).
 
-Operations on Registration Resources need to be ordered when the security mechanism does not provide freshness guarantees.
-{{freshness}} outlines ways to do that and consequences of accepting stale requests.
-
 Simple registration could be used to circumvent address-based access control:
 An attacker would send a simple registration request with the victim's address as source address,
 and later look up the victim's /.well-known/core content in the RD.

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1178,8 +1178,8 @@ After the initial registration, the registering endpoint retains the returned lo
 
 The Registration Resource may also be used cancel the registration using DELETE, and to perform further operations beyond the scope of this specification.
 
-Some operations on the registration resource are sensitive to long-term reordering;
-{{freshness}} describes mechanisms against that.
+Operations on the Registration Resource are sensitive to reordering;
+{{freshness}} describes how order is restored.
 
 The operations on the Registration Resource are described below.
 


### PR DESCRIPTION
This is an initial rough and overly variable suggestion to address the issues discussed as a follow-up to the DTLS replay window comments.

The approaches all have their up- and downsides, and I'm not sure yet which are worth keeping.

* The nice thing about ETag is that it should be largely uncontroversial in its semantics, well established, and resource specific. The only downside is that we'd have to mandate that the client send it every time, for otherwise there's no way of recovery. (And recovery is needed: Think of what happens if the client sends a request, the server updates the ETag and returns it with a response that gets lost. Client retransmits, but the request is idempotent and thus not deduplicated, and the client gets a 4.12. Or can that carry an ETag? It probably intends to tag a representation. And can the server 4.12 when ETag is missing?)

* Echo is what we talked about in the last interim, and largely straightforward. It's really about freshness and not about resource state, and thus may need to play nicely with other users of Echo on the same server.

* Introspecting OSCORE sequence numbers ... do we want to go there? (And if yes, can we do anything for DTLS where sequence numbers are usually not exposed through the libraries?)

  It wouldn't be fully without precedent because the sequence numbers are used to order observe notifications, and were under consideration (but insufficient for) atomic block reassembly. However, these were about CoAP options and not applications. How to tell the client to re-encrypt at seqno failure is open (although Echo:anything-but-the-current-value would practically suffice). Further questions arise when there are multiple OSCORE contexts all admissible for interaction with that resource.

* Unique Registration Resource names are just in there for completeness, they don't give a full solution.