### PR TITLE
Promote CoAP, HTTP and Web Linking RFCs to normative references

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -70,12 +70,13 @@ normative:
   RFC6570:
   RFC6763: dnssd
 #  RFC7396:
-informative:
+  RFC7230:
   RFC7252:
+  RFC8288:
+informative:
   RFC7390:
   RFC6775:
   RFC6874:
-  RFC7230:
   RFC8132:
 #  RFC3629: utf8
 #  RFC5198: nvt-utf8
@@ -83,7 +84,6 @@ informative:
 #  RFC1034: dns1
   RFC7641:
   ER: DOI.10.1145/320434.320440
-  RFC8288:
   I-D.silverajan-core-coap-protocol-negotiation:
   I-D.ietf-ace-oauth-authz:
   I-D.ietf-core-links-json:


### PR DESCRIPTION
CoAP and HTTP are both optional but that still makes them normative; Web
Linking is used to define our terminology and the information model.

[1]: https://ietf.org/about/groups/iesg/statements/normative-informative-references/
See-Also: https://datatracker.ietf.org/doc/draft-ietf-core-resource-directory/ballot/#benjamin-kaduk