### PR TITLE
Interactions: Can also be initiated by CT

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -2270,6 +2270,8 @@ changes from -25 to -26
 * Terminology:
   * Clarify that the CTs' installation events can occur multiple times.
 
+* Interaction tables: list CTs as possible initiators where applicable
+
 changes from -24 to -25
 
 

--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -752,7 +752,7 @@ The discovery request interface is specified as follows
 with the additional requirement that the server MUST support query filtering):
 
 Interaction:
-: EP and Client -> RD
+: EP, CT or Client -> RD
 
 Method:
 : GET
@@ -875,7 +875,7 @@ Its behavior with representations outside that subset is implementation defined.
 The registration request interface is specified as follows:
 
 Interaction:
-: EP -> RD
+: EP or CT -> RD
 
 
 Method:
@@ -1201,7 +1201,7 @@ with the POST method to update the links of a registration (see {{link-up}}).
 The update registration request interface is specified as follows:
 
 Interaction:
-: EP -> RD
+: EP or CT -> RD
 
 Method:
 : POST
@@ -1337,7 +1337,7 @@ the endpoint resource.
 The removal request interface is specified as follows:
 
 Interaction:
-: EP -> RD
+: EP or CT -> RD
 
 Method:
 : DELETE


### PR DESCRIPTION
As the CT is kept distinct in the diagrams and definitions, we can't
"just mean EP or CT" in the interactions. This affects only regular
registration; simple is not for CTs.

See-Also: https://datatracker.ietf.org/doc/draft-ietf-core-resource-directory/ballot/#benjamin-kaduk