### PR TITLE
Description of "et": Fix title

### DIFF
--- a/draft-ietf-core-resource-directory.md
+++ b/draft-ietf-core-resource-directory.md
@@ -1947,7 +1947,7 @@ duplication of functionality (Is the new entry redundant with an existing one?),
 topical suitability (E.g. is the described property actually a property of the endpoint and not a property of a particular resource, in which case it should go into the payload of the registration and need not be registered?),
 and the potential for conflict with commonly used target attributes (For example, `if` could be used as a parameter for conditional registration if it were not to be used in lookup or attributes, but would make a bad parameter for lookup, because a resource lookup with an `if` query parameter could ambiguously filter by the registered endpoint property or the {{RFC6690}} target attribute).
 
-### Full description of the "Endpoint Type" Registration Parameter {#et-description}
+### Full description of the "Endpoint Type" RD Parameter {#et-description}
 
 An endpoint registering at an RD can describe itself with endpoint types,
 similar to how resources are described with Resource Types in {{RFC6690}}.


### PR DESCRIPTION
Closes: https://github.com/core-wg/resource-directory/issues/289

---

The title would have implied it's a registration-only parameter, while it's a general-purpose RD parameter as per the table and its intended use.